### PR TITLE
Add gitginore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+venv
+.env


### PR DESCRIPTION
Small PR to ignore the virtual env and the `.env` file. 

This way, users don't see a lot of untracked files when they follow the README